### PR TITLE
Enhance build and start commands in nixpacks.toml for better handling…

### DIFF
--- a/backend/nixpacks.toml
+++ b/backend/nixpacks.toml
@@ -2,7 +2,9 @@
 nixPkgs = ["openjdk17"]
 
 [phases.build]
-cmds = ["chmod +x ./gradlew", "./gradlew build -x test"]
+cmds = [
+	"if [ -f ./gradlew ]; then chmod +x ./gradlew; ./gradlew build -x test; else cd backend && chmod +x ./gradlew && ./gradlew build -x test; fi"
+]
 
 [start]
-cmd = "java -jar $(ls build/libs/*.jar | grep -v plain | head -n 1)"
+cmd = "JAR=$(ls -1 build/libs/*.jar backend/build/libs/*.jar 2>/dev/null | grep -v plain | head -n 1); echo \"Using jar: $JAR\"; test -n \"$JAR\"; java -jar \"$JAR\""


### PR DESCRIPTION
… of gradlew and jar files

## Summary by Sourcery

Improve Nixpacks build and start commands to be more robust in locating and running the Gradle wrapper and application JAR.

Build:
- Make the Nixpacks build phase handle projects where the Gradle wrapper and build are located either in the root or in the backend subdirectory.
- Update the Nixpacks start command to locate the built JAR from multiple possible output directories, validate its presence, and log which JAR is being run.